### PR TITLE
Optimizes and fixes authored/narrated books query

### DIFF
--- a/lib/ambry/authors.ex
+++ b/lib/ambry/authors.ex
@@ -7,21 +7,7 @@ defmodule Ambry.Authors do
   import Ecto.Query
 
   alias Ambry.Authors.Author
-  alias Ambry.Books.Book
   alias Ambry.Repo
-
-  @doc """
-  Gets an author and all of their books.
-
-  Books are listed in descending order based on publish date.
-  """
-  def get_author_with_books!(author_id) do
-    books_query = from b in Book, order_by: [desc: b.published]
-
-    Author
-    |> preload(books: ^{books_query, [:authors, series_books: :series]})
-    |> Repo.get!(author_id)
-  end
 
   @doc """
   Gets an author.

--- a/lib/ambry/narrators.ex
+++ b/lib/ambry/narrators.ex
@@ -6,22 +6,8 @@ defmodule Ambry.Narrators do
   import Ambry.SearchUtils
   import Ecto.Query
 
-  alias Ambry.Books.Book
   alias Ambry.Narrators.Narrator
   alias Ambry.Repo
-
-  @doc """
-  Gets a narrators and all of their books.
-
-  Books are listed in descending order based on publish date.
-  """
-  def get_narrator_with_books!(narrator_id) do
-    books_query = from b in Book, order_by: [desc: b.published]
-
-    Narrator
-    |> preload(books: ^{books_query, [:authors, series_books: :series]})
-    |> Repo.get!(narrator_id)
-  end
 
   @doc """
   Finds narrators that match a query string.


### PR DESCRIPTION
The order of authored or narrated books by person was meant to be in
descending published order, but this was broken.